### PR TITLE
Avoid possibly unnecessary list allocations in command.

### DIFF
--- a/src/Jinn/Command.cs
+++ b/src/Jinn/Command.cs
@@ -3,15 +3,15 @@ namespace Jinn;
 [PublicAPI]
 public class Command : Symbol
 {
-    private readonly List<Command> _commands = [];
-    private readonly List<Argument> _arguments = [];
-    private readonly List<Option> _options = [];
+    private List<Command>? _commands;
+    private List<Argument>? _arguments;
+    private List<Option>? _options;
 
     public string Name { get; }
 
-    public IReadOnlyList<Command> Commands => _commands;
-    public IReadOnlyList<Argument> Arguments => _arguments;
-    public IReadOnlyList<Option> Options => _options;
+    public IReadOnlyList<Command> Commands => (IReadOnlyList<Command>?)_commands ?? [];
+    public IReadOnlyList<Argument> Arguments => (IReadOnlyList<Argument>?)_arguments ?? [];
+    public IReadOnlyList<Option> Options => (IReadOnlyList<Option>?)_options ?? [];
 
     public bool HasArguments => Arguments.Count > 0;
     internal Func<InvocationContext, Task>? Handler { get; private set; }
@@ -23,17 +23,17 @@ public class Command : Symbol
 
     public void AddCommand(Command command)
     {
-        _commands.Add(command);
+        (_commands ??= []).Add(command);
     }
 
     public void AddArgument(Argument argument)
     {
-        _arguments.Add(argument);
+        (_arguments ??= []).Add(argument);
     }
 
     public void AddOption(Option option)
     {
-        _options.Add(option);
+        (_options ??= []).Add(option);
     }
 
     public void SetHandler(Action<InvocationContext> handler)


### PR DESCRIPTION
The command may not always contain arguments/options/sub-commands, and the list allocations might be wasteful. An empty list on x64 is 32 bytes.

I do usually use this pattern, but not sure if you like the verbosity here, and might be a bit nitpicking :)
If you prefer it, then there are other similar places to be refactored.